### PR TITLE
getting the parent revision id

### DIFF
--- a/lib/wikidata/diff/analyzer.rb
+++ b/lib/wikidata/diff/analyzer.rb
@@ -3,44 +3,17 @@
 require_relative "analyzer/version"
 require 'mediawiki_api'
 
-module Wikidata
-  module Diff
-    module Analyzer
-      class Error < StandardError; end
-
-      def self.get_parent_revision_id(current_revision_id)
-        client = MediawikiApi::Client.new('https://www.wikidata.org/w/api.php')
-        params = {
-          action: 'query',
-          prop: 'revisions',
-          titles: 'Data:Main_Page',
-          rvdir: 'older',
-          rvlimit: 2,
-          rvprop: 'ids',
-          format: 'json'
-        }
-        response = client.query(params)
-        pages = response.data['pages']
-        page_id = pages.keys[0]
-        revisions = pages[page_id]['revisions']
-
-        if revisions && revisions.length > 1
-          parent_revision_id = revisions[1]['revid']
-          return parent_revision_id
-        end
-
-        nil
-      end
-    end
+def get_parent_id(current_revision_id)
+  client = MediawikiApi::Client.new('https://www.wikidata.org/w/api.php')
+  response = client.action('compare', fromrev: current_revision_id, torelative: 'prev', format: 'json')
+  data = response.data
+  if data
+    parent_id = data['fromrevid']
+    return parent_id
+  else
+    return nil
   end
 end
 
-# Example usage
-current_revision_id = '1596238176'
-parent_revision_id = Wikidata::Diff::Analyzer.get_parent_revision_id(current_revision_id)
 
-if parent_revision_id
-  puts "Parent Revision ID: #{parent_revision_id}"
-else
-  puts 'No parent revision found.'
-end
+

--- a/lib/wikidata/diff/analyzer.rb
+++ b/lib/wikidata/diff/analyzer.rb
@@ -6,7 +6,36 @@ module Wikidata
   module Diff
     module Analyzer
       class Error < StandardError; end
-      # Your code goes here...
+      def get_parent_revision_id(current_revision_id):
+        # API endpoint URL
+        url = "https://www.wikidata.org/w/api.php"
+
+        # Parameters for the API request
+        params = {
+            "action": "query",
+            "prop": "revisions",
+            "revids": current_revision_id,
+            "rvdir": "older",
+            "rvlimit": "2",
+            "rvprop": "ids",
+            "format": "json"
+        }
+
+        # Send the API request
+        response = requests.get(url, params=params)
+        response_json = response.json()
+
+        # Extract parent revision ID from the response
+        pages = response_json["query"]["pages"]
+        page_id = list(pages.keys())[0]
+        revisions = pages[page_id]["revisions"]
+
+        # Check if the current revision has a parent revision
+        if len(revisions) > 1:
+            parent_revision_id = revisions[1]["revid"]
+            return parent_revision_id
+        return None
+      end
     end
   end
 end

--- a/lib/wikidata/diff/analyzer.rb
+++ b/lib/wikidata/diff/analyzer.rb
@@ -1,41 +1,46 @@
 # frozen_string_literal: true
 
 require_relative "analyzer/version"
+require 'mediawiki_api'
 
 module Wikidata
   module Diff
     module Analyzer
       class Error < StandardError; end
-      def get_parent_revision_id(current_revision_id):
-        # API endpoint URL
-        url = "https://www.wikidata.org/w/api.php"
 
-        # Parameters for the API request
+      def self.get_parent_revision_id(current_revision_id)
+        client = MediawikiApi::Client.new('https://www.wikidata.org/w/api.php')
         params = {
-            "action": "query",
-            "prop": "revisions",
-            "revids": current_revision_id,
-            "rvdir": "older",
-            "rvlimit": "2",
-            "rvprop": "ids",
-            "format": "json"
+          action: 'query',
+          prop: 'revisions',
+          titles: 'Data:Main_Page',
+          rvdir: 'older',
+          rvlimit: 2,
+          rvprop: 'ids',
+          format: 'json'
         }
+        response = client.query(params)
+        pages = response.data['pages']
+        page_id = pages.keys[0]
+        revisions = pages[page_id]['revisions']
 
-        # Send the API request
-        response = requests.get(url, params=params)
-        response_json = response.json()
+        if revisions && revisions.length > 1
+          parent_revision_id = revisions[1]['revid']
+          return parent_revision_id
+        end
 
-        # Extract parent revision ID from the response
-        pages = response_json["query"]["pages"]
-        page_id = list(pages.keys())[0]
-        revisions = pages[page_id]["revisions"]
-
-        # Check if the current revision has a parent revision
-        if len(revisions) > 1:
-            parent_revision_id = revisions[1]["revid"]
-            return parent_revision_id
-        return None
+        nil
       end
     end
   end
+end
+
+# Example usage
+current_revision_id = '1596238176'
+parent_revision_id = Wikidata::Diff::Analyzer.get_parent_revision_id(current_revision_id)
+
+if parent_revision_id
+  puts "Parent Revision ID: #{parent_revision_id}"
+else
+  puts 'No parent revision found.'
 end

--- a/spec/wikidata/diff/analyzer_spec.rb
+++ b/spec/wikidata/diff/analyzer_spec.rb
@@ -1,11 +1,28 @@
-# frozen_string_literal: true
+require './lib/wikidata/diff/analyzer'
+require 'rspec'
 
-RSpec.describe Wikidata::Diff::Analyzer do
-  it "has a version number" do
-    expect(Wikidata::Diff::Analyzer::VERSION).not_to be nil
-  end
+RSpec.describe 'Wikidata::Diff::Analyzer' do
+  describe '#get_parent_id' do
+    it 'returns the ID of the parent revision' do
+      # based on https://www.wikidata.org/w/index.php?title=Q111269579&diff=1596238100&oldid=1596236983
+      # I know the parent id of this revision 
+      # but have to brainstorm idea for other cases
+      current_revision_id = 1596238100
+      expected_parent_id = 1596236983
 
-  it "does something useful" do
-    expect(false).to eq(true)
+      parent_id = get_parent_id(current_revision_id)
+
+      expect(parent_id).to eq(expected_parent_id)
+    end
+
+    it 'returns nil if the current revision is the first revision' do
+      # for sure there's no parent revision for this
+      # https://www.wikidata.org/w/api.php?action=compare&fromrev=123&torelative=prev&format=json
+      current_revision_id = 123
+
+      parent_id = get_parent_id(current_revision_id)
+
+      expect(parent_id).to be_nil
+    end
   end
 end


### PR DESCRIPTION
- trying out different ideas including timestap, wikiurl, rvdir
- later figured out action=compare after reading wikidata documentation which was the game changer
- according to the provided example url https://www.wikidata.org/w/index.php?title=Q111269579&diff=1596238100&oldid=1596236983, parent id of 1596238100 is 1596236983
- current code can successfully fetch parent revid based on current revid
- if there's no parent id, it returns nil