### PR TITLE
calculating difference

### DIFF
--- a/lib/wikidata/diff/analyzer.rb
+++ b/lib/wikidata/diff/analyzer.rb
@@ -107,7 +107,7 @@ module WikidataDiffAnalyzer
 
 
     return 0 if content.nil?
-    
+
     claims = content['claims']
     return 0 unless claims.is_a?(Hash)
   
@@ -127,7 +127,19 @@ module WikidataDiffAnalyzer
         end
       end
     end
-  
     references_count
-  end    
+  end  
+  
+  # Gets the parent id based on current revision id from the action:compare at Wikidata API.
+  def self.get_parent_id(current_revision_id)
+    client = MediawikiApi::Client.new('https://www.wikidata.org/w/api.php')
+    response = client.action('compare', fromrev: current_revision_id, torelative: 'prev', format: 'json')
+    data = response.data
+    if data
+      parent_id = data['fromrevid']
+      return parent_id
+    else
+      return nil
+    end
+  end
 end

--- a/lib/wikidata/diff/analyzer.rb
+++ b/lib/wikidata/diff/analyzer.rb
@@ -142,4 +142,30 @@ module WikidataDiffAnalyzer
       return nil
     end
   end
+
+  # calculates the difference between two revisions based on the revision ids.
+  def self.calculate_diff(current_revision_id)
+    # get the parent revision id
+    parent_revision_id = get_parent_id(current_revision_id)
+    
+    # current claim and reference count
+    current_content = get_revision_content(current_revision_id)
+    current_claim_count = count_claims(current_content)
+    current_reference_count = count_references(current_content)
+
+    # parent claim and reference count
+    parent_content = get_revision_content(parent_revision_id)
+    parent_claim_count = count_claims(parent_content)
+    parent_reference_count = count_references(parent_content)
+
+    # calculate the difference
+    claim_diff = current_claim_count - parent_claim_count
+    reference_diff = current_reference_count - parent_reference_count
+
+    # return the difference
+    return {
+      claim_diff: claim_diff,
+      reference_diff: reference_diff
+    }
+  end
 end

--- a/lib/wikidata/diff/analyzer.rb
+++ b/lib/wikidata/diff/analyzer.rb
@@ -3,67 +3,131 @@
 require 'json'
 require 'mediawiki_api'
 
-module Wikidata
-  module Diff
-    module Analyzer
-      class Error < StandardError; end
+module WikidataDiffAnalyzer
+  class Error < StandardError; end
 
-      def self.get_revision_content(revision_id)
-        api_url = 'https://www.wikidata.org/w/api.php'
+# This method retrieves the content of a specific revision from the Wikidata API.
+# It takes a revision ID as input and returns the parsed content as a Ruby object.
+  def self.get_revision_content(revision_id)
+    api_url = 'https://www.wikidata.org/w/api.php'
 
-        client = MediawikiApi::Client.new(api_url)
-        response = client.action(
-          'query',
-          prop: 'revisions',
-          revids: revision_id,
-          rvslots: 'main',
-          rvprop: 'content',
-          format: 'json'
-        )
+    client = MediawikiApi::Client.new(api_url)
+    begin
+      response = client.action(
+        'query',
+        prop: 'revisions',
+        revids: revision_id,
+        rvslots: 'main',
+        rvprop: 'content',
+        format: 'json'
+      )
 
-        page_id = response.data['pages'].keys.first
-        revisions = response.data['pages'][page_id]['revisions']
-        first_revision = revisions[0]
-        content = first_revision['slots']['main']['*']
-        begin
-          parsed_content = JSON.parse(content)
-        rescue JSON::ParserError => e
-          puts "Error parsing JSON content: #{e.message}"
-          puts "Content: #{content}"
-          raise e
-        end
-        return parsed_content
-      end
+      # Get the page ID and revisions from the response
+      page_id = response.data['pages'].keys.first
+      revisions = response.data['pages'][page_id]['revisions']
+      first_revision = revisions[0]
 
-      def self.count_claims(content)
-        claims = content['claims']
-        # counting the number of elements inside the arrays in claims
-        if claims
-          claims_lengths = claims.map { |key, value| value.length }
-          total_length = claims_lengths.reduce(0) { |sum, length| sum + length }
-          return total_length
-        else
-          return 0
-        end
-      end
+      # Get the content of the first revision
+      content = first_revision['slots']['main']['*']
 
-      def self.count_references_recursive(content)
-        references_count = 0
-        if content.is_a?(Hash)
-          content.each do |key, value|
-            if key == 'references' && value.is_a?(Array)
-              references_count += value.length
-            elsif value.is_a?(Array) || value.is_a?(Hash)
-              references_count += count_references_recursive(value)
-            end
-          end
-        elsif content.is_a?(Array)
-          content.each do |item|
-            references_count += count_references_recursive(item)
-          end
-        end
-        return references_count
-      end      
+      # Parse the content as JSON
+      parsed_content = JSON.parse(content)
+
+      # Return the parsed content
+      return parsed_content
+    rescue MediawikiApi::ApiError => e
+      puts "Error retrieving revision content: #{e.message}"
+      return nil
+    rescue JSON::ParserError => e
+      puts "Error parsing JSON content: #{e.message}"
+      puts "Content: #{content}"
+      raise e
     end
   end
+
+
+# This method counts the total number of claims in the provided content.
+# It takes the parsed content as input and returns the count of claims.
+  def self.count_claims(content)
+    return 0 if content.nil?
+
+    claims = content['claims']
+
+    # Check if claims exist in the content
+    if claims
+      # Count the number of elements inside the arrays in claims
+      claims_lengths = claims.map { |key, value| value.length }
+      total_length = claims_lengths.reduce(0) { |sum, length| sum + length }
+      return total_length
+    else
+      # If no claims exist, return 0
+      return 0
+    end
+  end
+
+# This method counts the total number of references in the claims of the provided content.
+  def self.count_references(content)
+    # https://www.wikidata.org/w/api.php?action=query&prop=revisions&revids=1596238100&rvslots=main&rvprop=content&format=json
+    # Example claim P19 has 1 reference:
+    # {
+    #   "P19": [
+    #     {
+    #       "mainsnak": {
+    #         ...
+    #        },
+    #       "type": "statement",
+    #       "qualifiers": {
+    #         ...
+    #        },
+    #       "qualifiers-order": ["P17"],
+    #       "id": "Q111269579$8433a7ee-4e09-77aa-b472-7443d613d8fa",
+    #       "rank": "normal",
+    #       "references": [
+    #         {
+    #           "hash": "4c89fc0f26ea4ca4e70c64cb352f42843c5f0900",
+    #           "snaks": {
+    #             "P854": [
+    #               {
+    #                 "snaktype": "value",
+    #                 "property": "P854",
+    #                 "hash": "3260bea98a52f32c3a30041a3bd4dfe1dfb36cda",
+    #                 "datavalue": {
+    #                   "value": "https://trinidadexpress.com/opinion/columnists/ryan-recalls/article_8fe3c130-118e-11ea-b3e0-7fa49653edde.html",
+    #                   "type": "string"
+    #                 }
+    #               }
+    #             ]
+    #           },
+    #           "snaks-order": ["P854"]
+    #         }
+    #       ]
+    #     }
+    #   ]
+    # }
+
+
+    return 0 if content.nil?
+    
+    claims = content['claims']
+    return 0 unless claims.is_a?(Hash)
+  
+    references_count = 0
+  
+    # Iterate over the values of the claims hash
+    claims.values.each do |values|
+    # Check if values is an array
+      if values.is_a?(Array)
+      # Iterate over each value
+        values.each do |value|
+        # Check if the value has references and if references is an array
+          if value.key?('references') && value['references'].is_a?(Array)
+          # Increment the references count by the length of the references array
+            references_count += value['references'].length
+          end
+        end
+      end
+    end
+  
+    references_count
+  end    
 end

--- a/lib/wikidata/diff/analyzer.rb
+++ b/lib/wikidata/diff/analyzer.rb
@@ -170,6 +170,19 @@ module WikidataDiffAnalyzer
     end
   end
 
+  # Gets the child id based on parent revision id from the action:compare at Wikidata API.
+  def self.get_child_id(parent_revision_id)
+    client = MediawikiApi::Client.new('https://www.wikidata.org/w/api.php')
+    response = client.action('compare', fromrev: parent_revision_id, torelative: 'next', format: 'json')
+    data = response.data
+    if data
+      child_id = data['torevid']
+      return child_id
+    else
+      return nil
+    end
+  end
+
   # calculates the difference between two revisions based on the revision ids.
   def self.calculate_diff(current_revision_id)
     # get the parent revision id

--- a/spec/wikidata/diff/analyzer_spec.rb
+++ b/spec/wikidata/diff/analyzer_spec.rb
@@ -210,6 +210,28 @@ RSpec.describe 'count_references' do
   end
 end
 
+# test cases for count_qualifiers(Actual API request)
+# Individual Revision Id: 1596238100
+# JSON: https://www.wikidata.org/w/api.php?action=query&prop=revisions&revids=1596238100&rvslots=main&rvprop=content&format=json
+# HTML: https://www.wikidata.org/w/index.php?diff=1596238100
+
+# parent id of the above revision id: 1596236983
+# JSON: https://www.wikidata.org/w/api.php?action=query&prop=revisions&revids=1596236983&rvslots=main&rvprop=content&format=json
+# HTML: https://www.wikidata.org/w/index.php?diff=1596236983
+RSpec.describe '.count_qualifiers' do
+  # this test case expects the reference count to be 4 because the revision content has 4 references in the API request
+  it 'returns the number of qualifiers in the revision content' do
+    revision_id = 1596238100
+    content = WikidataDiffAnalyzer.get_revision_content(revision_id)
+    expect(WikidataDiffAnalyzer.count_qualifiers(content)).to eq(3)
+  end
+  it 'returns the number of qualifiers in the revision content' do
+    revision_id = 1596236983
+    content = WikidataDiffAnalyzer.get_revision_content(revision_id)
+    expect(WikidataDiffAnalyzer.count_qualifiers(content)).to eq(1)
+  end
+end
+
 # test cases for get_parent_id (Actual API request)
 RSpec.describe 'get_parent_id' do
   describe '#get_parent_id' do
@@ -252,9 +274,10 @@ RSpec.describe 'calculate_diff' do
   it 'returns the correct claim and reference diff' do
     diff = WikidataDiffAnalyzer.calculate_diff(1596238100)
     # based on the HTML https://www.wikidata.org/w/index.php?title=Q111269579&diff=1596238100&oldid=1596236983
-    # the diff is 1 claim and 1 reference
+    # the diff is 1 claim, 1 reference and 2 qualifiers
     expect(diff[:claim_diff]).to eq(1)
     expect(diff[:reference_diff]).to eq(1)
+    expect(diff[:qualifier_diff]).to eq(2)
   end
 end
 

--- a/spec/wikidata/diff/analyzer_spec.rb
+++ b/spec/wikidata/diff/analyzer_spec.rb
@@ -210,3 +210,41 @@ RSpec.describe 'count_references' do
   end
 end
 
+# test cases for get_parent_id (Actual API request)
+RSpec.describe 'get_parent_id' do
+  describe '#get_parent_id' do
+  # Individual Revision Id: 1596238100
+  # parent id of the above revision id: 1596236983
+
+  # JSON: https://www.wikidata.org/w/api.php?action=compare&fromrev=1596238100&torelative=prev&format=json
+  # HTML: https://www.wikidata.org/w/index.php?title=Q111269579&diff=1596238100&oldid=1596236983
+    it 'returns the ID of the parent revision' do
+      # based on https://www.wikidata.org/w/index.php?title=Q111269579&diff=1596238100&oldid=1596236983
+      # I know the parent id of this revision 
+      # but have to brainstorm idea for other cases
+      current_revision_id = 1596238100
+      expected_parent_id = 1596236983
+
+      parent_id = WikidataDiffAnalyzer.get_parent_id(current_revision_id)
+
+      expect(parent_id).to eq(expected_parent_id)
+    end
+
+  # Individual Revision Id: 123
+  # parent id of the above revision id: none
+
+  # JSON: https://www.wikidata.org/w/api.php?action=compare&fromrev=123&torelative=prev&format=json
+  # (returns a warning that there's no previous revision)
+  # HTML: https://www.wikidata.org/w/index.php?title=Q111269579&diff=123
+
+    it 'returns nil if the current revision is the first revision' do
+      # for sure there's no parent revision for this based on API response
+      # https://www.wikidata.org/w/api.php?action=compare&fromrev=123&torelative=prev&format=json
+      current_revision_id = 123
+      parent_id = WikidataDiffAnalyzer.get_parent_id(current_revision_id)
+      expect(parent_id).to be_nil
+    end
+  end
+end
+
+

--- a/spec/wikidata/diff/analyzer_spec.rb
+++ b/spec/wikidata/diff/analyzer_spec.rb
@@ -247,4 +247,15 @@ RSpec.describe 'get_parent_id' do
   end
 end
 
+# test cases for calculate_diff
+RSpec.describe 'calculate_diff' do
+  it 'returns the correct claim and reference diff' do
+    diff = WikidataDiffAnalyzer.calculate_diff(1596238100)
+    # based on the HTML https://www.wikidata.org/w/index.php?title=Q111269579&diff=1596238100&oldid=1596236983
+    # the diff is 1 claim and 1 reference
+    expect(diff[:claim_diff]).to eq(1)
+    expect(diff[:reference_diff]).to eq(1)
+  end
+end
+
 

--- a/spec/wikidata/diff/analyzer_spec.rb
+++ b/spec/wikidata/diff/analyzer_spec.rb
@@ -269,6 +269,26 @@ RSpec.describe 'get_parent_id' do
   end
 end
 
+# test cases for get_child_id (Actual API request)
+RSpec.describe 'get_child_id' do
+  describe '#get_child_id' do
+  # parent id of the above revision id: 1596236983
+  # Child Revision Id: 1596238100
+
+  # JSON: https://www.wikidata.org/w/api.php?action=compare&fromrev=1596236983&torelative=next&format=json
+  # HTML: https://www.wikidata.org/w/index.php?title=Q111269579&diff=1596238100&oldid=1596236983
+    it 'returns the ID of the parent revision' do
+      # based on https://www.wikidata.org/w/index.php?title=Q111269579&diff=1596238100&oldid=1596236983
+      parent_revision_id = 1596236983
+      expected_child_id = 1596238100
+
+      child_id = WikidataDiffAnalyzer.get_child_id(parent_revision_id)
+
+      expect(child_id).to eq(expected_child_id)
+    end
+  end
+end
+
 # test cases for calculate_diff
 RSpec.describe 'calculate_diff' do
   it 'returns the correct claim and reference diff' do


### PR DESCRIPTION
- get_parent_id: fetches the parent id of the current revision
- get_child_id: fetches child id of parent revision
- count_qualifiers: count the number of qualifiers of a revision object
- calculate_diff: calculates the difference between claim, reference, and qualifiers count between current and parent revision
- test cases test actual API request (current rev id: 1596238100) and passed