### PR TITLE
Expose merge counterparty Q-ids on per-revision diff

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -20,7 +20,7 @@ Metrics/BlockLength:
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 123
+  Max: 124
 
 # Offense count: 16
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [2.2.0]
+
+- Expose merge counterparty Q-ids on the diff. When a revision's edit comment is `wbmergeitems-to:…||Q…` or `wbmergeitems-from:…||Q…`, the per-revision diff now includes a `:merge_target` or `:merge_source` field with the parsed Q-id. Only present on the actual merge revision; existing counter fields are unchanged. Lets consumers reason about which item was merged into which without re-fetching the comment — needed to count merges when the source item is no longer in the consumer's tracked-articles list (e.g. PetScan-driven dashboards excluding redirects).
+
 ## [2.1.0]
 
 - Add configurable `User-Agent` for wikidata.org requests via `WikidataDiffAnalyzer.user_agent=`. Default identifies the gem; applications should override with their own so wikidata sysadmins can route any traffic concerns to the right party. Resolves anonymous-client 429s when running the spec suite or other unauthenticated callers.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    wikidata-diff-analyzer (2.1.0)
+    wikidata-diff-analyzer (2.2.0)
       json (~> 2.1)
       mediawiki_api
 

--- a/lib/wikidata-diff-analyzer/version.rb
+++ b/lib/wikidata-diff-analyzer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WikidataDiffAnalyzer
-  VERSION = '2.1.0'
+  VERSION = '2.2.0'
 end

--- a/lib/wikidata/diff/comment_analyzer.rb
+++ b/lib/wikidata/diff/comment_analyzer.rb
@@ -14,9 +14,22 @@ class CommentAnalyzer
 
     return phrases if comment.nil?
 
-    phrases[:merge_from] = 1 if comment.include?('wbmergeitems-from')
+    # Merge edit summaries embed the counterparty Q-id, e.g.
+    # "/* wbmergeitems-to:0||Q3350322 */". Capture it so consumers can tell
+    # which item was merged into which without re-fetching the comment.
+    if (m = comment.match(/wbmergeitems-from:\d*\|\|(Q\d+)/))
+      phrases[:merge_from] = 1
+      phrases[:merge_source] = m[1]
+    elsif comment.include?('wbmergeitems-from')
+      phrases[:merge_from] = 1
+    end
 
-    phrases[:merge_to] = 1 if comment.include?('wbmergeitems-to')
+    if (m = comment.match(/wbmergeitems-to:\d*\|\|(Q\d+)/))
+      phrases[:merge_to] = 1
+      phrases[:merge_target] = m[1]
+    elsif comment.include?('wbmergeitems-to')
+      phrases[:merge_to] = 1
+    end
 
     phrases[:redirect] = 1 if comment.include?('wbcreateredirect')
 

--- a/lib/wikidata/diff/revision_analyzer.rb
+++ b/lib/wikidata/diff/revision_analyzer.rb
@@ -82,6 +82,7 @@ class RevisionAnalyzer
     COMMENT_TYPES.each do |change_type|
       diff[change_type] = phrases[change_type]
     end
+    diff.merge!(phrases.slice(:merge_target, :merge_source))
 
     NOT_IN_ITEM.each do |change_type|
       diff[change_type] = 0

--- a/spec/wikidata/diff/comment_analyzer_spec.rb
+++ b/spec/wikidata/diff/comment_analyzer_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'wikidata/diff/comment_analyzer'
+
+RSpec.describe CommentAnalyzer do
+  describe '.isolate_comment_differences' do
+    it 'returns zeroed counters for nil and non-action comments' do
+      expect(CommentAnalyzer.isolate_comment_differences(nil)[:merge_to]).to eq(0)
+      expect(CommentAnalyzer.isolate_comment_differences('')[:merge_to]).to eq(0)
+      expect(CommentAnalyzer.isolate_comment_differences('plain edit')[:merge_to]).to eq(0)
+    end
+
+    it 'extracts the merge target Q-id from a wbmergeitems-to comment' do
+      result = CommentAnalyzer.isolate_comment_differences(
+        '/* wbmergeitems-to:0||Q3350322 */'
+      )
+      expect(result[:merge_to]).to eq(1)
+      expect(result[:merge_target]).to eq('Q3350322')
+    end
+
+    it 'extracts the merge source Q-id from a wbmergeitems-from comment' do
+      result = CommentAnalyzer.isolate_comment_differences(
+        '/* wbmergeitems-from:0||Q112434841 */'
+      )
+      expect(result[:merge_from]).to eq(1)
+      expect(result[:merge_source]).to eq('Q112434841')
+    end
+
+    it 'still flags a merge even if the Q-id cannot be parsed' do
+      result = CommentAnalyzer.isolate_comment_differences('wbmergeitems-to: weird format')
+      expect(result[:merge_to]).to eq(1)
+      expect(result[:merge_target]).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

When a Wikidata revision's edit comment is `wbmergeitems-to:…||Q…` or `wbmergeitems-from:…||Q…`, the per-revision diff hash now includes a `:merge_target` or `:merge_source` field with the parsed Q-id. Both fields are present only on the actual merge revision; otherwise they are omitted entirely (not zeroed-out), so existing equality-style specs that compare full diff hashes are not disturbed. Existing counter fields (`:merge_to`, `:merge_from`) are unchanged. The threading is done in the item branch of `RevisionAnalyzer` only — properties and lexemes cannot be merged via `wbmergeitems`.

Bumps version to 2.2.0.

## Motivation

Consumers of the gem need to reason about which item was merged into which to count merges correctly when the source item is no longer in the consumer's tracked-articles list. Concretely, on the WikiEduDashboard, PetScan-driven categories exclude redirects, so the moment a Wikidata item is merged its source title drops out of the tracked list and the merge_to revision is filtered out of the dashboard pipeline before reaching the analyzer (see WikiEduDashboard issue [#6813](https://github.com/WikiEducationFoundation/WikiEduDashboard/issues/6813)). With the merge target now on the diff, the dashboard can broaden its analyzer fan-in and admit `merge_to` from out-of-scope source revisions whose target is still in scope, without re-fetching the comment.

The paired dashboard PR consumes this field; its Gemfile points at this branch directly so CI exercises the integration.

## Test plan

End-to-end verification used the merge revisions from the WikiEduDashboard repro of issue #6813 (Q112434841→Q3350322 at rev 2477846959, Q112499989→Q106319567 at rev 2477847762): each round-tripped through `WikidataDiffAnalyzer.analyze` returns the expected `merge_target` Q-id. A focused unit spec for `CommentAnalyzer` covers nil/empty/plain comments, both merge directions with parseable Q-ids, and the malformed-but-still-flagged fallback.

## AI usage

This change was drafted by Claude Code (Anthropic's CLI for Claude) under human direction as part of investigating WikiEduDashboard issue #6813. Claude wrote the comment-parsing logic, the per-revision threading in `RevisionAnalyzer`, and the unit spec; the human author chose the field naming, the omit-when-absent convention, and the scope of the change. The commit message and this PR description were also drafted by Claude Code via the dashboard repo's `/prepare-pr` workflow and may contain errors — please review carefully. The work was completed in a single focused session.

(PR description written by Claude Code.)